### PR TITLE
Bugfix: resources were not correctly freed

### DIFF
--- a/gcf_docker_plugin/dockercontainer.py
+++ b/gcf_docker_plugin/dockercontainer.py
@@ -70,8 +70,6 @@ class DockerContainer(ExtendedResource):
     def deallocate(self):
         super(DockerContainer, self).deallocate()
         self.available=True
-        if (self.dockermaster is not None):
-            self.dockermaster.onDeallocateContainer(container=None, resources=[self])
 
     def getPort(self):
         return self.ssh_port
@@ -149,11 +147,16 @@ class DockerContainer(ExtendedResource):
         r = super(DockerContainer, self).genAdvertNode(_urn_authority, _my_urn)
         return r
 
-    # def reset(self):
-    #     super(DockerContainer, self).reset()
-    #     self._agg.deallocate(container=None, resources=[self])
-    #     self.image = None
-    #     self.error = ''
+    #This is called when the AM releases the resource (when deleting the sliver)
+    def reset(self):
+        super(DockerContainer, self).reset()
+        # don't think this one is needed
+        # self._agg.deallocate(container=None, resources=[self])
+        self.image = None
+        self.error = ''
+        #let the DockerMaster know that this resource is available again
+        if (self.dockermaster is not None):
+            self.dockermaster.onResetChild(self)
 
     def waitForSshConnection(self):
         """

--- a/gcf_docker_plugin/dockermaster.py
+++ b/gcf_docker_plugin/dockermaster.py
@@ -47,9 +47,8 @@ class DockerMaster(ExtendedResource):
         self.pool = [DockerContainer(self, starting_ipv4_port, dockermanager, host, ipv6_prefix)
                      for _ in range(max_slots)]
 
-    def onDeallocateContainer(self, container, resources):
-        # THIS IS NOT AN OVERWRITE OF, SO DONT: # super(DockerMaster, self).deallocate()
-        self.pool.extend(resources)
+    def onResetChild(self, childResource):
+        self.pool.append(childResource)
 
     def genAdvertNode(self, _urn_authority, _my_urn):
         r = super(DockerMaster, self).genAdvertNode(_urn_authority, _my_urn)

--- a/gcf_docker_plugin/extendedresource.py
+++ b/gcf_docker_plugin/extendedresource.py
@@ -210,11 +210,10 @@ class ExtendedResource(Resource):
     def size(self):
         return 1
 
-    # #Set the instance in the original state
-    # def reset(self):
-    #     super(ExtendedResource, self).reset()
-    #     todo #todo figure out what reset is used for, remove if not used
-    #     self.error = ''
+    #This is called when the AM releases the resource (when deleting the sliver)
+    def reset(self):
+        super(ExtendedResource, self).reset()
+        self.error = ''
 
     #A "blocking" method which return True when the SSH connection is available = The node is fully ready for the user
     #Should return True, or set self.error with an error message and return False

--- a/gcf_docker_plugin/testbed.py
+++ b/gcf_docker_plugin/testbed.py
@@ -388,14 +388,16 @@ class DockerAggregateManager(am3.ReferenceAggregateManager):
         available = self.resources(available=True)
         available = sorted(available, key=lambda a: a.size(), reverse=True)
                 
-        # Note: This only handles unbound nodes. Any attempt by the client
-        # to specify a node is ignored.
-        unbound = list()
+        # Note: We only care about nodes for this component manager.
+        #       nodes without component_manager_id or with a component_manager_id of another AM are ignored
+        local_nodes = list()
         for node_elem in rspec_dom.documentElement.getElementsByTagName('node'):
             if node_elem.getAttribute("component_manager_id") == self._my_urn:
-                unbound.append(node_elem)
+                local_nodes.append(node_elem)
 
-        if len(unbound)==0:
+        # If there are no nodes in the RSpec that we should handle, the AM specification does not tell us what to do.
+        # In general, it is best to throw the SEARCH_FAILED error, because silently doing nothing is potentially too confusing.
+        if len(local_nodes)==0:
             ALLOCATE_LOCK.release()
             return self.errorResult(am3.AM_API.SEARCH_FAILED, "No requested resource can be allocated on this AM. "
                                                               "Check your request (usually bad component_manager_id)")
@@ -421,7 +423,7 @@ class DockerAggregateManager(am3.ReferenceAggregateManager):
             proxy_resource.image = None
             resources.append(proxy_resource)
 
-        for node_elem in unbound:
+        for node_elem in local_nodes:
             client_id = node_elem.getAttribute('client_id')
             if client_id == "" or client_id is None:
                 abort_resource_allocation()


### PR DESCRIPTION
After the latest code changes, resources were no longer being correctly freed (inside the AM, the containters themself were correctly freed), resulting in no containers being available anymore.
This bug was fixed by re-adding and extending `def reset()`